### PR TITLE
chore: add migration to sync model schema and recreate database

### DIFF
--- a/Migrations/20260210061140_SyncModelSchema.Designer.cs
+++ b/Migrations/20260210061140_SyncModelSchema.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using SiperuBackend.Data;
 
@@ -10,9 +11,11 @@ using SiperuBackend.Data;
 namespace SiperuBackend.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260210061140_SyncModelSchema")]
+    partial class SyncModelSchema
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.2");

--- a/Migrations/20260210061140_SyncModelSchema.cs
+++ b/Migrations/20260210061140_SyncModelSchema.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace SiperuBackend.Migrations
+{
+    /// <inheritdoc />
+    public partial class SyncModelSchema : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.InsertData(
+                table: "Rooms",
+                columns: new[] { "Id", "Capacity", "CreatedAt", "Description", "IsAvailable", "Name" },
+                values: new object[,]
+                {
+                    { 6, 30, new DateTime(2026, 2, 8, 0, 0, 0, 0, DateTimeKind.Utc), "Lab Multimedia", true, "Lab Komputer 2" },
+                    { 7, 100, new DateTime(2026, 2, 8, 0, 0, 0, 0, DateTimeKind.Utc), "Untuk seminar dan presentasi", true, "Ruang Seminar" }
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "Rooms",
+                keyColumn: "Id",
+                keyValue: 6);
+
+            migrationBuilder.DeleteData(
+                table: "Rooms",
+                keyColumn: "Id",
+                keyValue: 7);
+        }
+    }
+}


### PR DESCRIPTION
- Create SyncModelSchema migration for pending model changes
- Database now includes all seed data (7 rooms, 3 bookings)
- Resolves model/schema mismatch issues